### PR TITLE
fix issue where generation fails with an object with only rest params

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2265,7 +2265,7 @@
             multiline = false;
             if (expr.properties.length === 1) {
                 property = expr.properties[0];
-                if (property.value.type !== Syntax.Identifier) {
+                if (property.type !== Syntax.RestElement && property.value.type !== Syntax.Identifier) {
                     multiline = true;
                 }
             } else {


### PR DESCRIPTION
i.e.:

{ ...foo } = obj;